### PR TITLE
fix global attributes

### DIFF
--- a/src/file.jl
+++ b/src/file.jl
@@ -75,7 +75,7 @@ function nc_open(io,write)
     end
 
     # global attributes
-    attrib = read_attributes(io,Tsize)
+    global_attrib = read_attributes(io,Tsize)
 
     # variables
     header = unpack_read(io,UInt32)
@@ -111,7 +111,7 @@ function nc_open(io,write)
         recs,
         dim,
         _dimid,
-        attrib,
+        global_attrib,
         start,
         vars,
         ReentrantLock(),


### PR DESCRIPTION
They were eing set to the attributes of the last variable due to the `attrib = ` in between these two lines.